### PR TITLE
Added MCP3008_ADC component 

### DIFF
--- a/ic/mcp3008_adc/mcp3008_adc.xml
+++ b/ic/mcp3008_adc/mcp3008_adc.xml
@@ -6,7 +6,7 @@
 <meta value="1.1" name="version"/>
 <meta value="90" name="minsize"/>
 <meta value="circuitdiagram" name="author"/>
-<meta value="a45e7fb6-561b-4fa1-b688-7764d881e114" name="guid"/>
+<meta value="d45e7fb6-561b-4fa1-b688-7764d881e114" name="guid"/>
 <meta value="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/components/common" name="implementset"/>
 <meta value="MCP3008" name="implementitem"/>
 -<flags>

--- a/ic/mcp3008_adc/mcp3008_adc.xml
+++ b/ic/mcp3008_adc/mcp3008_adc.xml
@@ -1,0 +1,146 @@
+<component version="1.4" xmlns="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/component/xml">
+
+-<declaration>
+<meta value="MCP3008" name="name"/>
+<meta value="8-channel 10-bit analog to digital converter." name="description"/>
+<meta value="1.1" name="version"/>
+<meta value="90" name="minsize"/>
+<meta value="circuitdiagram" name="author"/>
+<meta value="a45e7fb6-561b-4fa1-b688-7764d881e114" name="guid"/>
+<meta value="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/components/common" name="implementset"/>
+<meta value="MCP3008" name="implementitem"/>
+-<flags>
+<option>horizontalonly</option>
+</flags>
+</declaration>
+-<connections>
+-<group>
+<!-- Left side pins -->
+
+
+<connection name="analog_0" edge="Start" end="_Middle-40x-30y" start="_Start-30y"/>
+
+<connection name="analog_1" edge="Start" end="_Middle-40x-10y" start="_Start-10y"/>
+
+<connection name="analog_2" edge="Start" end="_Middle-40x+10y" start="_Start+10y"/>
+
+<connection name="analog_3" edge="Start" end="_Middle-40x+30y" start="_Start+30y"/>
+
+<connection name="analog_4" edge="Start" end="_Middle-40x-30y" start="_Start-40y"/>
+
+<connection name="analog_5" edge="Start" end="_Middle-40x-10y" start="_Start-20y"/>
+
+<connection name="analog_6" edge="Start" end="_Middle-40x+10y" start="_Start+20y"/>
+
+<connection name="analog_7" edge="Start" end="_Middle-40x+30y" start="_Start+40y"/>
+
+<!-- Right side pins -->
+
+
+<connection name="power_supply_pin" edge="End" end="_End-30y" start="_Middle+40x-30y"/>
+
+<connection name="voltage_reference" edge="End" end="_End-20y" start="_Middle+40x-20y"/>
+
+<connection name="ground1" edge="End" end="_End-10y" start="_Middle+40x-10y"/>
+
+<connection name="clock_pin" edge="End" end="_End" start="_Middle+40x"/>
+
+<connection name="master_out_slave_in" edge="End" end="_End+10y" start="_Middle+40x+10y"/>
+
+<connection name="master_in_slave_out" edge="End" end="_End+20y" start="_Middle+40x+20y"/>
+
+<connection name="chip_selection" edge="End" end="_End+30y" start="_Middle+40x+30y"/>
+
+<connection name="ground2" edge="End" end="_End+30y" start="_Middle+40x+30y"/>
+
+
+</group>
+
+</connections>
+
+
+-<render>
+
+
+-<group>
+
+<path start="_Middle" data="m -40,-40 l 35,0 a 5 5 180 0 0 10 0 l 35,0 l 0,160 l -80,0 l 0,-160 z"/>
+
+<text value="MCP" align="CentreCentre" y="_Middle+27" x="_Middle"/>
+
+<text value="3008" align="CentreCentre" y="_Middle+37" x="_Middle"/>
+
+<!-- Left side pins -->
+
+
+<text value="A0" align="CentreLeft" y="_Middle-30" x="_Middle-36"/>
+
+<line end="_Middle-40x-30y" start="_Start-30y"/>
+
+<text value="A1" align="CentreLeft" y="_Middle-10" x="_Middle-36"/>
+
+<line end="_Middle-40x-10y" start="_Start-10y"/>
+
+<text value="A2" align="CentreLeft" y="_Middle+10" x="_Middle-36"/>
+
+<line end="_Middle-40x+10y" start="_Start+10y"/>
+
+<text value="A3" align="CentreLeft" y="_Middle+30" x="_Middle-36"/>
+
+<line end="_Middle-40x+30y" start="_Start+30y"/>
+
+<text value="A4" align="CentreLeft" y="_Middle+50" x="_Middle-36"/>
+
+<line end="_Middle-40x+50y" start="_Start+50y"/>
+
+<text value="A5" align="CentreLeft" y="_Middle+70" x="_Middle-36"/>
+
+<line end="_Middle-40x+70y" start="_Start+70y"/>
+
+<text value="A6" align="CentreLeft" y="_Middle+90" x="_Middle-36"/>
+
+<line end="_Middle-40x+90y" start="_Start+90y"/>
+
+<text value="A7" align="CentreLeft" y="_Middle+110" x="_Middle-36"/>
+
+<line end="_Middle-40x+110y" start="_Start+110y"/>
+<!-- Right side pins -->
+
+
+<text value="VDD" align="CentreRight" y="_Middle-30" x="_Middle+36"/>
+
+<line end="_End-30y" start="_Middle+40x-30y"/>
+
+<text value="VREF" align="CentreRight" y="_Middle-10" x="_Middle+36"/>
+
+<line end="_End-10y" start="_Middle+40x-10y"/>
+
+<text value="AGND" align="CentreRight" y="_Middle+10" x="_Middle+36"/>
+
+<line end="_End+10y" start="_Middle+40x+10y"/>
+
+<text value="CLK" align="CentreRight" y="_Middle+30" x="_Middle+36"/>
+
+<line end="_End+30y" start="_Middle+40x+30y"/>
+
+<text value="DOUT" align="CentreRight" y="_Middle+50" x="_Middle+36"/>
+
+<line end="_End+50y" start="_Middle+40x+50y"/>
+
+<text value="DIN" align="CentreRight" y="_Middle+70" x="_Middle+36"/>
+
+<line end="_End+70y" start="_Middle+40x+70y"/>
+
+<text value="CS/SHDN" align="CentreRight" y="_Middle+90" x="_Middle+36"/>
+
+<line end="_End+90y" start="_Middle+40x+90y"/>
+
+<text value="DGND" align="CentreRight" y="_Middle+110" x="_Middle+36"/>
+
+<line end="_End+110y" start="_Middle+40x+110y"/>
+
+</group>
+
+</render>
+
+</component>


### PR DESCRIPTION
Description taken from [AdaFruit](https://learn.adafruit.com/raspberry-pi-analog-to-digital-converters/mcp3008)

The MCP3008 is a low cost 8-channel 10-bit analog to digital converter.  The precision of this ADC is similar to that of an Arduino Uno, and with 8 channels you can read quite a few analog signals from the Pi.  This chip is a great option if you just need to read simple analog signals, like from a temperature or light sensor.  If you need more precision or features, check out the ADS1x115 series on the next page.