### PR TITLE
added representation for capacitively shunted junction

### DIFF
--- a/misc/josephson_junction/josephson_junction.xml
+++ b/misc/josephson_junction/josephson_junction.xml
@@ -2,15 +2,15 @@
 <component version="1.5" xmlns="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/component/xml">
   <declaration>
     <meta name="name" value="Josephson Junction" />
-    <meta name="version" value="1.0.0" />
     <meta name="minsize" value="50" />
     <meta name="author" value="err4re" />
     <meta name="guid" value="97d08ed6-6b4d-4fa2-b456-394a6a94f27e" />
+    <meta name="org.circuit-diagram.bundled" value="true" />
     <meta name="experimental.definitions.enabled" value="true" />
 
     <property name="Text" type="string" default="" serialize="text" display="Text" />
 
-    <property name="CriticalCurrent" type="decimal" default="1100" serialize="criticalCurrent" display="Critical Current (in uA)">
+    <property name="CriticalCurrent" type="decimal" default="1000" serialize="CriticalCurrent" display="Critical Current (in \u03BCA)">
       <formatting>
         <format conditions="$CriticalCurrent[lt]1000" value="$CriticalCurrent  \u03BCA"/>
         <format conditions="$CriticalCurrent[lt]1000000" value="$CriticalCurrent(div_1000)(round_1)  mA" />
@@ -19,6 +19,9 @@
     </property>
 
     <property name="ShowCriticalCurrent" type="bool" default="true" serialize="showCriticalCurrent" display="Show Critical Current" />
+
+    <property name="ShuntedJunction" type="bool" default="true" serialize="shuntedJunction" display="Shunt Junction with Capacitance" />
+
   </declaration>
 
   <definitions>
@@ -27,8 +30,8 @@
       <when conditions="!horizontal" value="CentreRight" />
     </def>
     <def name="TextOffsetS">
-      <when conditions="!horizontal|!$ShowCriticalCurrent" value="-18" />
-      <when conditions="horizontal,$ShowCriticalCurrent" value="-30" />
+      <when conditions="!horizontal|!$ShowCriticalCurrent" value="-14" />
+      <when conditions="horizontal,$ShowCriticalCurrent" value="-26" />
     </def>
     <def name="TextOffsetP">
       <when conditions="horizontal|!$ShowCriticalCurrent" value="0" />
@@ -41,24 +44,30 @@
     </def>
   </definitions>
 
-  <connections autorotate="HorizontalToVertical">
+  <connections>
     <group>
-      <connection name="a" start="_Start" end="_Middle-10x" edge="start" />
-      <connection name="b" start="_Middle+10x" end="_End" edge="end" />
+      <connection start="_Start" end="_End" edge="both" />
     </group>
   </connections>
-
-  <render autorotate="HorizontalToVertical">    
-    <line start="_Start" end="_End" />
-    <line start="_Middle+10x+10y" end="_Middle-10x-10y" />
-    <line start="_Middle-10x+10y" end="_Middle+10x-10y" />
+  <render autorotate="HorizontalToVertical">
   
-    <!-- Text -->
     <g conditions="$ShowCriticalCurrent">
       <text value="$CriticalCurrent" x="_Middle+$CriticalCurrentOffsetP" y="_Start+$CriticalCurrentOffsetS" align="$TextAlignment" />
     </g>
     <g conditions="$Text">
       <text value="$Text" x="_Middle+$TextOffsetP" y="_Start+$TextOffsetS" align="$TextAlignment" />
+    </g>
+    <g conditions="!$ShuntedJunction">
+      <line start="_Start" end="_End" />
+      <line start="_Middle+10x+10y" end="_Middle-10x-10y" />
+      <line start="_Middle-10x+10y" end="_Middle+10x-10y" />
+    </g>
+    <g conditions="$ShuntedJunction">
+      <line start="_Start" end="_Middle-10x" />
+      <line start="_Middle+10x" end="_End" />
+      <line start="_Middle+10x+10y" end="_Middle-10x-10y" />
+      <line start="_Middle-10x+10y" end="_Middle+10x-10y" />
+      <rect location="_Middle-10x-10y" width="20" height="20" />
     </g>
   </render>
 </component>


### PR DESCRIPTION
Now you can choose between two symbols for Josephson Junctions:
1. ideal junction (just a cross)
2. capacitively shunted junction (cross in a box)