### PR TITLE
Fixed Push to Break Switch not toggling

### DIFF
--- a/common/switch/switch.xml
+++ b/common/switch/switch.xml
@@ -136,13 +136,25 @@
       <line start="_Middle+14x" end="_Middle+30x" />
     </group>
     
-    <!-- Push to Break -->
-    <group conditions="horizontal,$Type==PushToBreak">
+    <!-- Push to Break (Open) -->
+    <group conditions="horizontal,$Type==PushToBreak,!$Closed">
+      <line start="_Middle-12x+8y" end="_Middle+12x+8y" />
+      <line start="_Middle-5x+2y" end="_Middle+5x+2y" />
+      <line start="_Middle+2y" end="_Middle+8y" />
+    </group>
+    <group conditions="!horizontal,$Type==PushToBreak,!$Closed">
+      <line start="_Middle+8x-12y" end="_Middle+8x+12y" />
+      <line start="_Middle+2x-5y" end="_Middle+2x+5y" />
+      <line start="_Middle+2x" end="_Middle+8x" />
+    </group>
+    
+    <!-- Push to Break (Closed) -->
+    <group conditions="horizontal,$Type==PushToBreak,$Closed">
       <line start="_Middle-12x+5y" end="_Middle+12x+5y" />
       <line start="_Middle-5x-1y" end="_Middle+5x-1y" />
       <line start="_Middle-1y" end="_Middle+5y" />
     </group>
-    <group conditions="!horizontal,$Type==PushToBreak">
+    <group conditions="!horizontal,$Type==PushToBreak,$Closed">
       <line start="_Middle+5x-12y" end="_Middle+5x+12y" />
       <line start="_Middle-1x-5y" end="_Middle-1x+5y" />
       <line start="_Middle-1x" end="_Middle+5x" />


### PR DESCRIPTION
Push to Break switches are now toggleable by ticking the _closed_ property.

Closed | Open
------- | --------
![Closed Push to Break Switch](https://user-images.githubusercontent.com/41258075/127113394-8555676f-a407-4f04-8b3d-5780b4cf5f12.png) | ![Open Push to Break Switch](https://user-images.githubusercontent.com/41258075/127113434-f533628a-86f9-4956-aecb-a24a057ebb1b.png)