### PR TITLE
Multiple fixes for fuse

### DIFF
--- a/common/fuse/fuse.xml
+++ b/common/fuse/fuse.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component version="1.2" xmlns="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/component/xml">
+<component version="1.5" xmlns="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/component/xml">
   <declaration>
     <meta name="name" value="Fuse" />
-    <meta name="version" value="1.2.0" />
+    <meta name="version" value="2.0.0" />
     <meta name="minsize" value="50" />
     <meta name="author" value="Circuit Diagram" />
     <meta name="additionalinformation" value="http://www.circuit-diagram.org/" />
@@ -10,6 +10,9 @@
     <meta name="implementset" value="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/components/common" />
     <meta name="implementitem" value="fuse" />
     <meta name="org.circuit-diagram.bundled" value="true" />
+    <meta name="experimental.definitions.enabled" value="true" />
+
+    <property name="Text" type="string" default="" serialize="text" display="Text" />
 
     <property name="Value" type="decimal" default="2" serialize="value" display="Value">
       <formatting>
@@ -18,27 +21,42 @@
         <format value="$Value(round_1)  A" />
       </formatting>
     </property>
+
+    <property name="ShowValue" type="bool" default="true" serialize="showValue" display="Show Value" />
   </declaration>
-  <connections>
-    <group conditions="horizontal">
-      <connection name="a" start="_Start" end="_Middle-21x" edge="start" />
-      <connection name="b" start="_Middle+21x" end="_End" edge="end" />
-    </group>
-    <group conditions="!horizontal">
-      <connection name="a" start="_Start" end="_Middle-21y" edge="start" />
-      <connection name="b" start="_Middle+21y" end="_End" edge="end" />
-    </group>
+  <definitions>
+    <def name="TextAlignment">
+      <when conditions="horizontal" value="BottomCentre" />
+      <when conditions="!horizontal" value="CentreRight" />
+    </def>
+    <def name="TextOffsetS">
+      <when conditions="!horizontal|!$ShowValue" value="-14" />
+      <when conditions="horizontal,$ShowValue" value="-26" />
+    </def>
+    <def name="TextOffsetP">
+      <when conditions="horizontal|!$ShowValue" value="0" />
+      <when conditions="!horizontal,$ShowValue" value="-6" />
+    </def>
+    <const name="ResistanceOffsetS" value="-14" />
+    <def name="ResistanceOffsetP">
+      <when conditions="horizontal|!$Text" value="0" />
+      <when conditions="!horizontal,$Text" value="6" />
+    </def>
+    <const name="StyleTextOffsetS" value="0" />
+  </definitions>
+  <connections autorotate="HorizontalToVertical">
+    <connection name="a" start="_Start" end="_Middle-21x" edge="start" />
+    <connection name="b" start="_Middle+21x" end="_End" edge="end" />
   </connections>
-  <render>
-    <group conditions="horizontal">
-      <rect x="_Middle-20" y="_Middle-8" width="40" height="16" />
-      <line start="_Start" end="_End" />
-      <text value="$Value" x="_Middle" y="_Start-17" align="CentreCentre" />
-    </group>
-    <group conditions="!horizontal">
-      <rect x="_Middle-8" y="_Middle-20" width="16" height="40" />
-      <line start="_Start" end="_End" />
-      <text value="$Value" x="_Start-14" y="_Middle" align="CentreRight" />
-    </group>
+  <render autorotate="HorizontalToVertical">
+    <line start="_Start" end="_End" />
+    <rect location="_Middle-20x-8y" width="40" height="16" />
+
+    <g conditions="$ShowValue">
+      <text value="$Value" x="_Middle+$ResistanceOffsetP" y="_Start+$ResistanceOffsetS+$StyleTextOffsetS" align="$TextAlignment" />
+    </g>
+    <g conditions="$Text">
+      <text value="$Text" x="_Middle+$TextOffsetP" y="_Start+$TextOffsetS+$StyleTextOffsetS" align="$TextAlignment" />
+    </g>
   </render>
 </component>


### PR DESCRIPTION
Updates Fuse with 1.5 features to bring it in line with similar components such as Resistor and Inductor, which should also fix #105 and fix #148 in the process. Extra commits are provided to preserve a record of 1.2-compatible issue fixes as well.