### PR TITLE
Add extra open/close states for the switches

### DIFF
--- a/common/switch/switch.xml
+++ b/common/switch/switch.xml
@@ -42,7 +42,7 @@
     </group>
     <group conditions="!horizontal,!$Type==Changeover">
       <connection name="a" start="_Start" end="_Middle-16y" edge="Start" />
-      <connection name="a" start="_Middle+16y" end="_End" edge="End" />
+      <connection name="b" start="_Middle+16y" end="_End" edge="End" />
     </group>
     <group conditions="horizontal,$Type==Analogue">
       <connection name="c" start="_Middle-30y" end="_Middle-14y" edge="Start" />

--- a/common/switch/switch.xml
+++ b/common/switch/switch.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <component version="1.2" xmlns="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/component/xml">
   <declaration>
     <meta name="name" value="Switch" />
@@ -136,13 +136,25 @@
       <line start="_Middle+14x" end="_Middle+30x" />
     </group>
     
-    <!-- Push to Break -->
-    <group conditions="horizontal,$Type==PushToBreak">
+    <!-- Push to Break (Open) -->
+    <group conditions="horizontal,$Type==PushToBreak,!$Closed">
+      <line start="_Middle-12x+8y" end="_Middle+12x+8y" />
+      <line start="_Middle-5x+2y" end="_Middle+5x+2y" />
+      <line start="_Middle+2y" end="_Middle+8y" />
+    </group>
+    <group conditions="!horizontal,$Type==PushToBreak,!$Closed">
+      <line start="_Middle+8x-12y" end="_Middle+8x+12y" />
+      <line start="_Middle+2x-5y" end="_Middle+2x+5y" />
+      <line start="_Middle+2x" end="_Middle+8x" />
+    </group>
+    
+    <!-- Push to Break (Closed) -->
+    <group conditions="horizontal,$Type==PushToBreak,$Closed">
       <line start="_Middle-12x+5y" end="_Middle+12x+5y" />
       <line start="_Middle-5x-1y" end="_Middle+5x-1y" />
       <line start="_Middle-1y" end="_Middle+5y" />
     </group>
-    <group conditions="!horizontal,$Type==PushToBreak">
+    <group conditions="!horizontal,$Type==PushToBreak,$Closed">
       <line start="_Middle+5x-12y" end="_Middle+5x+12y" />
       <line start="_Middle-1x-5y" end="_Middle-1x+5y" />
       <line start="_Middle-1x" end="_Middle+5x" />


### PR DESCRIPTION
This adds an open rendering for the "push to break" switch, using the same 3px gap as the "push" switch.
![image](https://github.com/user-attachments/assets/aa9c5121-1bf6-487b-8273-4c237559e006)
![image](https://github.com/user-attachments/assets/af0fb376-06c2-4b39-a1a6-a3c8cea0b87e)
