### PR TITLE
Add an NC relay and an energised option

### DIFF
--- a/common/relay_2/relay_2.xml
+++ b/common/relay_2/relay_2.xml
@@ -2,7 +2,7 @@
 <component version="1.5" xmlns="http://schemas.circuit-diagram.org/circuitDiagramDocument/2012/component/xml">
   <declaration>
     <meta name="name" value="Relay 2" />
-    <meta name="version" value="1.0.0" />
+    <meta name="version" value="1.1.0" />
     <meta name="minsize" value="80" />
     <meta name="author" value="Circuit Diagram" />
     <meta name="additionalinformation" value="http://www.circuit-diagram.org/" />

--- a/common/relay_2/relay_2.xml
+++ b/common/relay_2/relay_2.xml
@@ -11,10 +11,12 @@
 
     <property name="Type" type="enum" default="SPST_NO" serialize="t" display="Type">
       <option>SPST_NO</option>
+      <option>SPST_NC</option>
     </property>
 
     <configurations>
       <configuration name="Relay SPST-NO" value="Type:SPST_NO" implements="relayspstno" />
+      <configuration name="Relay SPST-NC" value="Type:SPST_NC" implements="relayspstnc" />
     </configurations>
 
     <flags>
@@ -41,6 +43,11 @@
     <line start="_Middle+14x-30y" end="_End-30y" />
     <ellipse centre="_Middle-11x-30y" rx="3" ry="3" />
     <ellipse centre="_Middle+11x-30y" rx="3" ry="3" />
-    <line start="_Middle-9x-38y" end="_Middle+8x-32y" />
+    <group conditions="$Type==SPST_NO">
+      <line start="_Middle-9x-38y" end="_Middle+8x-32y" />
+    </group>
+    <group conditions="$Type==SPST_NC">
+      <line start="_Middle-9x-26y" end="_Middle+8x-28y" />
+    </group>
   </render>
 </component>

--- a/common/relay_2/relay_2.xml
+++ b/common/relay_2/relay_2.xml
@@ -14,6 +14,8 @@
       <option>SPST_NC</option>
     </property>
 
+    <property name="Energised" type="bool" default="false" serialize="energised" display="Energised" />
+
     <configurations>
       <configuration name="Relay SPST-NO" value="Type:SPST_NO" implements="relayspstno" />
       <configuration name="Relay SPST-NC" value="Type:SPST_NC" implements="relayspstnc" />
@@ -43,11 +45,17 @@
     <line start="_Middle+14x-30y" end="_End-30y" />
     <ellipse centre="_Middle-11x-30y" rx="3" ry="3" />
     <ellipse centre="_Middle+11x-30y" rx="3" ry="3" />
-    <group conditions="$Type==SPST_NO">
+    <group conditions="$Type==SPST_NO,!$Energised">
       <line start="_Middle-9x-38y" end="_Middle+8x-32y" />
     </group>
-    <group conditions="$Type==SPST_NC">
+    <group conditions="$Type==SPST_NO,$Energised">
+      <line start="_Middle-9x-34y" end="_Middle+8x-32y" />
+    </group>
+    <group conditions="$Type==SPST_NC,!$Energised">
       <line start="_Middle-9x-26y" end="_Middle+8x-28y" />
+    </group>
+    <group conditions="$Type==SPST_NC,$Energised">
+      <line start="_Middle-9x-22y" end="_Middle+8x-28y" />
     </group>
   </render>
 </component>


### PR DESCRIPTION
Adds a SPST_NC relay type to relay_2, with a new "energised" property too.

`$Type=SPST_NC`
![image](https://github.com/user-attachments/assets/aa924e1f-7053-4c2c-a1c2-49e1ac9587d5)

`$Type=SPST_NO,$Energised=true`
![image](https://github.com/user-attachments/assets/352cf1a0-4d3a-4065-acec-edc667f2e786)

`$Type=SPST_NC,$Energised=true`
![image](https://github.com/user-attachments/assets/34702d78-e224-48e9-8203-b654f82c589f)
